### PR TITLE
Add last modified support

### DIFF
--- a/cmd/rtrmon/rtrmon.go
+++ b/cmd/rtrmon/rtrmon.go
@@ -44,7 +44,8 @@ var (
 	MetricsPath = flag.String("metrics", "/metrics", "Metrics path")
 	OutFile     = flag.String("file", "diff.json", "Diff file (or URL path without /)")
 
-	UserAgent = flag.String("useragent", fmt.Sprintf("StayRTR-%v (+https://github.com/bgp/stayrtr)", AppVersion), "User-Agent header")
+	UserAgent                  = flag.String("useragent", fmt.Sprintf("StayRTR-%v (+https://github.com/bgp/stayrtr)", AppVersion), "User-Agent header")
+	DisableConditionalRequests = flag.Bool("disable.conditional.requests", false, "Disable conditional requests (using If-None-Match/If-Modified-Since headers)")
 
 	PrimaryHost            = flag.String("primary.host", "tcp://rtr.rpki.cloudflare.com:8282", "primary server")
 	PrimaryValidateCert    = flag.Bool("primary.tls.validate", true, "Validate TLS")
@@ -685,6 +686,8 @@ func main() {
 	log.SetLevel(lvl)
 
 	fc := utils.NewFetchConfig()
+	fc.EnableEtags = !*DisableConditionalRequests
+	fc.EnableLastModified = !*DisableConditionalRequests
 	fc.UserAgent = *UserAgent
 
 	c1 := NewClient()

--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -12,13 +12,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	rtr "github.com/bgp/stayrtr/lib"
-	"github.com/bgp/stayrtr/prefixfile"
-	"github.com/bgp/stayrtr/utils"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -28,6 +21,14 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	rtr "github.com/bgp/stayrtr/lib"
+	"github.com/bgp/stayrtr/prefixfile"
+	"github.com/bgp/stayrtr/utils"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
 )
 
 const (
@@ -85,6 +86,7 @@ var (
 	UseSerial = flag.String("useserial", "disable", "Use serial contained in file (disable, startup, full)")
 
 	Etag            = flag.Bool("etag", true, "Enable Etag header")
+	LastModified    = flag.Bool("last.modified", true, "Enable Last-Modified header")
 	UserAgent       = flag.String("useragent", fmt.Sprintf("StayRTR-%v (+https://github.com/bgp/stayrtr)", AppVersion), "User-Agent header")
 	Mime            = flag.String("mime", "application/json", "Accept setting format (some servers may prefer text/json)")
 	RefreshInterval = flag.Int("refresh", 600, "Refresh interval in seconds")
@@ -589,6 +591,7 @@ func main() {
 	s.fetchConfig.UserAgent = *UserAgent
 	s.fetchConfig.Mime = *Mime
 	s.fetchConfig.EnableEtags = *Etag
+	s.fetchConfig.EnableLastModified = *LastModified
 
 	if serialId, ok := serialToId[*UseSerial]; ok {
 		s.useSerial = serialId


### PR DESCRIPTION
Adds `Last-Modified` header support and enables this (and `ETag`s)
by default for rtrmon.

I'm using rtrmon with a backend that suports `If-Modified-Since`
but not `If-None-Match`. To poll this often (sub-minute interval)
it is better to use conditional requests.

I am not sure if it makes sense to enable this by default for `stayrtr`. My understanding is that the combination of both headers should be handled properly by back-ends (and are sent by browsers) - so it should be safe to do.

Furthermore I am not a golang expert, so this change is a bit mechanical, let me know what you think.