### PR TITLE
Track objects that differ for a longer period separately

### DIFF
--- a/cmd/rtrmon/rtrmon.go
+++ b/cmd/rtrmon/rtrmon.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -34,6 +35,8 @@ const (
 	METHOD_PASSWORD
 	METHOD_KEY
 )
+
+type thresholds []int64
 
 var (
 	version    = ""
@@ -133,7 +136,7 @@ var (
 		2: "secondary",
 	}
 
-	VisibilityThresholds = []int64{0, 56, 256, 596, 851, 1024, 1706, 3411}
+	visibilityThresholds = thresholds{0, 56, 256, 596, 851, 1024, 1706, 3411}
 )
 
 func init() {
@@ -143,6 +146,39 @@ func init() {
 	prometheus.MustRegister(RTRSerial)
 	prometheus.MustRegister(RTRSession)
 	prometheus.MustRegister(LastUpdate)
+
+	flag.Var(&visibilityThresholds, "visibility.thresholds", "comma-separated list of visibility thresholds to override the default")
+}
+
+// String formats an array of thresholds as a comma separated string.
+func (t *thresholds) String() string {
+	res := []byte("")
+	for idx, tr := range *t {
+		res = strconv.AppendInt(res, tr, 10)
+		if idx < len(*t)-1 {
+			res = append(res, ","...)
+		}
+	}
+	return string(res)
+}
+
+func (t *thresholds) Set(value string) error {
+	// Setting overrides current values
+	if len(*t) > 0 {
+		*t = thresholds{}
+	}
+
+	for _, tr := range strings.Split(value, ",") {
+		threshold, err := strconv.ParseInt(tr, 10, 32)
+
+		if err != nil {
+			return err
+		}
+
+		*t = append(*t, threshold)
+	}
+
+	return nil
 }
 
 func decodeJSON(data []byte) (*prefixfile.VRPList, error) {
@@ -631,7 +667,7 @@ func (c *Comparator) Compare() {
 					"type":   "diff",
 				}).Set(float64(len(onlyIn2)))
 
-			for _, visibleFor := range VisibilityThresholds {
+			for _, visibleFor := range visibilityThresholds {
 				thresholdTimestamp := time.Now().Unix() - visibleFor
 				// Prevent differences with value 0 appearing if the process has not
 				// been running long enough for them to exist.


### PR DESCRIPTION
Use case: track how long it takes for VRPs in one endpoint (could be an internal source of truth or a RP) in another.

For example:
```
# HELP vrp_diff Number of VRPS in [lhs_url] that are not in [rhs_url] that were first seen [visibility_seconds] ago in lhs.
# TYPE vrp_diff gauge
vrp_diff{lhs_url="https://routinator-demo.aws.nlnetlabs.nl/json",rhs_url="tcp://rtr.rpki.cloudflare.com:8282",visibility_seconds="0"} 2241
vrp_diff{lhs_url="https://routinator-demo.aws.nlnetlabs.nl/json",rhs_url="tcp://rtr.rpki.cloudflare.com:8282",visibility_seconds="256"} 2240
vrp_diff{lhs_url="https://routinator-demo.aws.nlnetlabs.nl/json",rhs_url="tcp://rtr.rpki.cloudflare.com:8282",visibility_seconds="56"} 2241
vrp_diff{lhs_url="tcp://rtr.rpki.cloudflare.com:8282",rhs_url="https://routinator-demo.aws.nlnetlabs.nl/json",visibility_seconds="0"} 5
vrp_diff{lhs_url="tcp://rtr.rpki.cloudflare.com:8282",rhs_url="https://routinator-demo.aws.nlnetlabs.nl/json",visibility_seconds="256"} 5
vrp_diff{lhs_url="tcp://rtr.rpki.cloudflare.com:8282",rhs_url="https://routinator-demo.aws.nlnetlabs.nl/json",visibility_seconds="56"} 5
```
What you see here is that one of the VRPs not present in the routinator endpoint is "recent".

When you monitor multiple instances (for example, one `rsync` vs `rrdp`, or `stayrtr` vs its input) a time-lag between various instances is logical. This time lag is not guaranteed to "go to 0" when there are continuous updates. My experience is that alerting on objects that have been seen for a while prevents spurious alerts.

This is available in a container for testing at https://hub.docker.com/repository/docker/tiesdekock/rtrmon