### PR TITLE
Add dockerhub build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,58 @@
+name: CI to Docker Hub
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push (stayrtr)
+        id: docker_build_stayrtr
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile.stayrtr.prod
+          push: true
+          tags: rpki/stayrtr:latest
+
+      - name: Image digest (stayrtr)
+        run: echo ${{ steps.docker_build_stayrtr.outputs.digest }}
+
+      - name: Build and push (rtrmon)
+        id: docker_build_rtrmon
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile.rtrmon.prod
+          push: true
+          tags: rpki/rtrmon:latest
+
+      - name: Image digest (rtrmon)
+        run: echo ${{ steps.docker_build_rtrmon.outputs.digest }}
+
+      - name: Build and push rtrdump
+        id: docker_build_rtrdump
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile.rtrdump.prod
+          push: true
+          tags: rpki/rtrdump:latest
+
+      - name: Image digest (rtrdump)
+        run: echo ${{ steps.docker_build_rtrdump.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ StayRTR is an open-source implementation of RPKI to Router protocol (RFC 6810) b
 This project is not affiliated with Cloudflare and any references to Cloudflare are simply a function of forking. We do love the Cloudyflares though!
 
 * `/lib` contains a library to create your own server and client.
-* `/prefixfile` contains the structure of a JSON export file and signing capabilities.
+* `/prefixfile` contains the structure of a JSON export file.
 * `/cmd/stayrtr/stayrtr.go` is a simple implementation that fetches a list and offers it to a router.
 * `/cmd/rtrdump/rtrdump.go` allows copying the PDUs sent by a RTR server as a JSON file.
 * `/cmd/rtrmon/rtrmon.go` compare and monitor two RTR servers (using RTR and/or JSON), outputs diff and Prometheus metrics.
@@ -106,16 +106,6 @@ Or you can use a package (or binary) file from the [Releases page](https://githu
 ```bash
 $ sudo dpkg -i stayrtr[...].deb
 $ sudo systemctl start stayrtr
-```
-
-If you want to sign your list of prefixes, generate an ECDSA key.
-Then generate the public key to be used in StayRTR.
-You will have to setup your validator to use this key or have another
-tool to sign the JSON file before passing it to StayRTR.
-
-```bash
-$ openssl ecparam -genkey -name prime256v1 -noout -outform pem > private.pem
-$ openssl ec -in private.pem -pubout -outform pem > public.pem
 ```
 
 ## Run it
@@ -269,11 +259,15 @@ Use your own validator, as long as the JSON source follows the following schema:
 
 ```
 {
+  "metadata": {
+    "buildtime": "2021-07-18T13:36:26Z"
+    ...
+  },
   "roas": [
     {
       "prefix": "10.0.0.0/24",
       "maxLength": 24,
-      "asn": "AS65001"
+      "asn": 65001
     },
     ...
   ]

--- a/prefixfile/prefixfile.go
+++ b/prefixfile/prefixfile.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strconv"
-	"strings"
 )
 
 type VRPJson struct {
@@ -28,16 +26,6 @@ type VRPList struct {
 
 func (vrp *VRPJson) GetASN2() (uint32, error) {
 	switch asnc := vrp.ASN.(type) {
-	case string:
-		asnStr := strings.TrimLeft(asnc, "aAsS")
-		asnInt, err := strconv.ParseUint(asnStr, 10, 32)
-		if err != nil {
-			return 0, errors.New(fmt.Sprintf("Could not decode ASN: %v as part of VRP", vrp.ASN))
-		}
-		asn := uint32(asnInt)
-		return asn, nil
-	case float64:
-		return uint32(asnc), nil
 	case int:
 		return uint32(asnc), nil
 	default:

--- a/prefixfile/slurm.go
+++ b/prefixfile/slurm.go
@@ -2,7 +2,6 @@ package prefixfile
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net"
 )
@@ -18,9 +17,6 @@ func (pf *SlurmPrefixFilter) GetASN() (uint32, bool) {
 		return 0, true
 	} else {
 		switch asn := pf.ASN.(type) {
-		case json.Number:
-			c, _ := asn.Int64()
-			return uint32(c), false
 		case uint32:
 			return asn, false
 		default:
@@ -144,7 +140,7 @@ func (s *SlurmLocallyAddedAssertions) AssertVRPs() []VRPJson {
 			maxLength = size
 		}
 		vrps = append(vrps, VRPJson{
-			ASN:    fmt.Sprintf("AS%v", assertion.ASN),
+			ASN:    assertion.ASN,
 			Prefix: assertion.Prefix,
 			Length: uint8(maxLength),
 			TA:     assertion.Comment,

--- a/prefixfile/slurm_test.go
+++ b/prefixfile/slurm_test.go
@@ -78,22 +78,22 @@ func TestDecodeJSON(t *testing.T) {
 func TestFilterOnVRPs(t *testing.T) {
 	vrps := []VRPJson{
 		VRPJson{
-			ASN:    "AS65001",
+			ASN:    uint32(65001),
 			Prefix: "192.168.0.0/25",
 			Length: 25,
 		},
 		VRPJson{
-			ASN:    "AS65002",
+			ASN:    uint32(65002),
 			Prefix: "192.168.1.0/24",
 			Length: 24,
 		},
 		VRPJson{
-			ASN:    "AS65003",
+			ASN:    uint32(65003),
 			Prefix: "192.168.2.0/24",
 			Length: 24,
 		},
 		VRPJson{
-			ASN:    "AS65004",
+			ASN:    uint32(65004),
 			Prefix: "10.0.0.0/24",
 			Length: 24,
 		},


### PR DESCRIPTION
I finally got around to trying to port the build for the docker containers. The environment variables should already have been setup.

However, only for `rtrmon` and `rtrdump` the repositories do not exist.

If everything works out, this should create three images for every commit on master.

# To do:
  [ ] Validate environment variables have been setup
  [ ] https://hub.docker.com/r/rpki/rtrmon repository
  [ ] https://hub.docker.com/r/rpki/rtrdump repository