### PR TITLE
Fix Docker push of shortened SHA

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
+      - name: Get short SHA from commit hash
+        id: shacalc
+        run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+
       - name: Check Out Repo
         uses: actions/checkout@v2
 
@@ -28,7 +31,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: true
-          tags: rpki/stayrtr:latest,rpki/stayrtr:${GITHUB_SHA::8}
+          tags: rpki/stayrtr:latest,rpki/stayrtr:${{ steps.shacalc.outputs.sha8 }}
           target: stayrtr
 
       - name: Image digest (stayrtr)
@@ -41,7 +44,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: true
-          tags: rpki/rtrmon:latest,rpki/rtrmon:${GITHUB_SHA::8}
+          tags: rpki/rtrmon:latest,rpki/rtrmon:${{ steps.shacalc.outputs.sha8 }}
           target: rtrmon
 
       - name: Image digest (rtrmon)
@@ -54,7 +57,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: true
-          tags: rpki/rtrdump:latest,rpki/rtrdump:${GITHUB_SHA::8}
+          tags: rpki/rtrdump:latest,rpki/rtrdump:${{ steps.shacalc.outputs.sha8 }}
           target: rtrdump
 
       - name: Image digest (rtrdump)


### PR DESCRIPTION
Push was failing due to a bash syntax that was not interpreted inside the environment variable.