### PR TITLE
Bump to 1.16 and remove deprecated package

### DIFF
--- a/cmd/rtrdump/rtrdump.go
+++ b/cmd/rtrdump/rtrdump.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"runtime"
@@ -189,7 +188,7 @@ func main() {
 				keyBytesStr := os.Getenv(ENV_SSH_KEY)
 				keyBytes = []byte(keyBytesStr)
 			} else {
-				keyBytes, err = ioutil.ReadFile(*SSHAuthKey)
+				keyBytes, err = os.ReadFile(*SSHAuthKey)
 				if err != nil {
 					log.Fatal(err)
 				}

--- a/cmd/rtrmon/rtrmon.go
+++ b/cmd/rtrmon/rtrmon.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -810,7 +809,7 @@ func main() {
 			keyBytesStr := os.Getenv(fmt.Sprintf("%s_1", ENV_SSH_KEY))
 			keyBytes = []byte(keyBytesStr)
 		} else {
-			keyBytes, err = ioutil.ReadFile(*PrimarySSHAuthKey)
+			keyBytes, err = os.ReadFile(*PrimarySSHAuthKey)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -842,7 +841,7 @@ func main() {
 			keyBytesStr := os.Getenv(fmt.Sprintf("%s_2", ENV_SSH_KEY))
 			keyBytes = []byte(keyBytesStr)
 		} else {
-			keyBytes, err = ioutil.ReadFile(*SecondarySSHAuthKey)
+			keyBytes, err = os.ReadFile(*SecondarySSHAuthKey)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -612,7 +611,7 @@ func main() {
 		}()
 	}
 	if *BindSSH != "" {
-		sshkey, err := ioutil.ReadFile(*SSHKey)
+		sshkey, err := os.ReadFile(*SSHKey)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -647,7 +646,7 @@ func main() {
 			if *SSHAuthKeysList == "" {
 				sshClientKeysToDecode = os.Getenv(ENV_SSH_KEY)
 			} else {
-				sshClientKeysToDecodeBytes, err := ioutil.ReadFile(*SSHAuthKeysList)
+				sshClientKeysToDecodeBytes, err := os.ReadFile(*SSHAuthKeysList)
 				if err != nil {
 					log.Fatal(err)
 				}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bgp/stayrtr
 
-go 1.12
+go 1.16
 
 require (
 	github.com/prometheus/client_golang v0.9.2

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -161,7 +160,7 @@ func (c *FetchConfig) FetchFile(file string) ([]byte, int, bool, error) {
 			return nil, -1, false, err
 		}
 	}
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return nil, -1, false, err
 	}


### PR DESCRIPTION
If you're happy to move to Go 1.16 that is. ioutil was deprecated in 1.16 and functions moved to other packages