### PR TITLE
Controversial change...

### DIFF
--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -485,6 +485,13 @@ func (m *metricsEvent) UpdateMetrics(numIPv4 int, numIPv6 int, numIPv4filtered i
 }
 
 func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	flag.Parse()
@@ -701,4 +708,5 @@ func main() {
 
 	s.routineUpdate(*CacheBin, *RefreshInterval, slurmFile)
 
+	return nil
 }


### PR DESCRIPTION
There may be pushback for this change, but hear me out. Two reasons I moved main to run:
1 - This is a good overview as to the why: https://pace.dev/blog/2020/02/12/why-you-shouldnt-use-func-main-in-golang-by-mat-ryer.html
2 - main() is currently 218 lines long. As as noted before it's difficult to test. Doing it this way makes it easier.

Long term, the vast majority of the initial set up should be in their own functions and run() should merely call these functions to set up that state, then downloading VRPs, then sitting and waiting for clients.