### PR TITLE
GOMAXPROCS

### DIFF
--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -379,7 +378,7 @@ func (s *state) routineUpdate(file string, interval int, slurmFile string) {
 	signal.Notify(signals, syscall.SIGHUP)
 	for {
 		var delay *time.Timer
-		if (s.lastchange.IsZero()) {
+		if s.lastchange.IsZero() {
 			log.Warn("Initial sync not complete. Refreshing every 30 seconds")
 			delay = time.NewTimer(time.Duration(30) * time.Second)
 		} else {
@@ -498,8 +497,6 @@ func main() {
 }
 
 func run() error {
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	flag.Parse()
 	if flag.NArg() > 0 {
 		fmt.Printf("%s: illegal positional argument(s) provided (\"%s\") - did you mean to provide a flag?\n", os.Args[0], strings.Join(flag.Args(), " "))
@@ -542,7 +539,7 @@ func run() error {
 
 	s := state{
 		server:       server,
-		lastdata:    &prefixfile.VRPList{},
+		lastdata:     &prefixfile.VRPList{},
 		metricsEvent: me,
 		sendNotifs:   *SendNotifs,
 		checktime:    *TimeCheck,

--- a/cmd/stayrtr/stayrtr_test.go
+++ b/cmd/stayrtr/stayrtr_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net"
+	"os"
 	"testing"
 
 	rtr "github.com/bgp/stayrtr/lib"
@@ -88,17 +89,17 @@ func TestProcessData(t *testing.T) {
 	got, count, v4count, v6count := processData(stuff)
 	want := []rtr.VRP{
 		{
-			Prefix: MustParseIPNet("192.168.0.0/24"),
+			Prefix: mustParseIPNet("192.168.0.0/24"),
 			MaxLen: 24,
 			ASN:    123,
 		},
 		{
-			Prefix: MustParseIPNet("2001:db8::/32"),
+			Prefix: mustParseIPNet("2001:db8::/32"),
 			MaxLen: 33,
 			ASN:    123,
 		},
 		{
-			Prefix: MustParseIPNet("192.168.1.0/24"),
+			Prefix: mustParseIPNet("192.168.1.0/24"),
 			MaxLen: 25,
 			ASN:    123,
 		},
@@ -112,13 +113,23 @@ func TestProcessData(t *testing.T) {
 	}
 }
 
-// MustParseIPNet is a test helper function to return a net.IPNet
+// mustParseIPNet is a test helper function to return a net.IPNet
 // This should only be called in test code, and it'll panic on test set up
 // if unable to parse.
-func MustParseIPNet(prefix string) net.IPNet {
+func mustParseIPNet(prefix string) net.IPNet {
 	_, ipnet, err := net.ParseCIDR(prefix)
 	if err != nil {
 		panic(err)
 	}
 	return *ipnet
+}
+
+func BenchmarkDecodeJSON(b *testing.B) {
+	json, err := os.ReadFile("test.rpki.json")
+	if err != nil {
+		panic(err)
+	}
+	for n := 0; n < b.N; n++ {
+		decodeJSON(json)
+	}
 }


### PR DESCRIPTION
Two things:

Setting GOMAXPROCS to the number of CPUs has been the default since 1.5 - https://dave.cheney.net/tag/gomaxprocs - This command is only useful if you're trying to limit the amount of cores to an app. But we're using all

Moving MustParse to mustParse so it's not exported from the package