### PR TITLE
Revert defer unlock in StayRTR AddVRPs

### DIFF
--- a/lib/server.go
+++ b/lib/server.go
@@ -346,7 +346,6 @@ func (s *Server) SetSerial(serial uint32) {
 
 func (s *Server) AddVRPs(vrps []VRP) {
 	s.vrplock.RLock()
-	defer s.vrplock.RUnlock()
 
 	vrpCurrent := s.vrpCurrent
 
@@ -357,6 +356,7 @@ func (s *Server) AddVRPs(vrps []VRP) {
 		s.log.Debugf("Computed diff: added (%d), removed (%d), unchanged (%d)", len(added), len(removed), len(unchanged))
 	}
 	curDiff := append(added, removed...)
+	s.vrplock.RUnlock()
 
 	s.AddVRPsDiff(curDiff)
 }


### PR DESCRIPTION
vrplock needs to be unlocked before AddVRPsDiff() because AddVRPsDiff needs a full lock.

I added some debug logging found this deadlock

INFO[0000] new cache file: Updating sha256 hash  -> da753c7804d6f386bf303fed6931853eaaca0771ba160ef7fdbebb17e899d78b
INFO[0001] New update (306189 uniques, 306189 total prefixes).
INFO[0001] RLocking vrplock in AddVRPs
INFO[0002] RLocking vrplock in AddVRPsDiff
INFO[0002] RUnlocked vrplock in AddVRPsDiff
INFO[0002] Locking vrplock in AddVRPsDiff
...