### PR TITLE
return if no vrps are loaded

### DIFF
--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -255,6 +255,11 @@ func (e IdenticalFile) Error() string {
 func (s *state) updateFromNewState() error {
 	sessid := s.server.GetSessionId()
 
+	vrpsjson := s.lastdata.Data
+	if (vrpsjson == nil) {
+		return nil
+	}
+
 	if s.checktime {
 		buildtime, err := time.Parse(time.RFC3339, s.lastdata.Metadata.Buildtime)
 		if err != nil {
@@ -266,7 +271,6 @@ func (s *state) updateFromNewState() error {
 		}
 	}
 
-	vrpsjson := s.lastdata.Data
 	if s.slurm != nil {
 		kept, removed := s.slurm.FilterOnVRPs(vrpsjson)
 		asserted := s.slurm.AssertVRPs()
@@ -600,7 +604,7 @@ func run() error {
 	// Initial calculation of state (after fetching cache + slurm)
 	err = s.updateFromNewState()
 	if err != nil {
-		log.Warnf("Error setting up intial state: %s", err)
+		log.Warnf("Error setting up initial state: %s", err)
 	}
 
 	if *Bind != "" {


### PR DESCRIPTION
If the VRP set can't be retrieved, an error pops up:

```
feather$ ./stayrtr -cache http://localhost/
ERRO[0000] Error updating: Get "http://localhost/": dial tcp [::1]:80: connect: connection refused
WARN[0000] Error setting up intial state: parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"
WARN[0000] Initial sync not complete. Refreshing every 30 seconds
INFO[0000] StayRTR Server started (sessionID:44976, refresh:3600, retry:600, expire:7200)
```

This PR silences the error by returning before the checkTime/buildtime dance - but I'm not sure if that's the best path forward.