### PR TITLE
Add index page to rtrmon

### DIFF
--- a/cmd/rtrmon/index.html.tmpl
+++ b/cmd/rtrmon/index.html.tmpl
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>rtrmon</title>
+</head>
+<body>
+    <h1><a href="https://github.com/bgp/stayrtr">rtrmon</a></h1>
+    <ul>
+        <li><a href="{{ .MetricsPath }}">prometheus metrics</a></li>
+        <li><a href="{{ .OutFile }}">diff file</a></li>
+    </ul>
+
+    <h2>usage</h2>
+    <h3>diff:</h3>
+    The <kbd>/{{ .OutFile }}</kbd> endpoint contains four keys:
+
+    <pre>
+    metadata-primary: configuration of the primary source
+    metadata-secondary: configuration of the secondary source
+    only-primary: objects in the primary source but not in the secondary source.
+    only-secondary: objects in the secondary source but not in the primary source.
+    </pre>
+
+    <h3>metrics:</h3>
+    By default the Prometheus endpoint is on <kbd>http://[host]{{ .Addr }}{{ .MetricsPath }}</kbd>. Among others, this endpoint contains the following metrics:
+
+    <pre>
+    rpki_vrps: Current number of VRPS and current difference between the primary and secondary.
+    rtr_serial: Serial of the rtr session (when applicable).
+    rtr_session: Session ID of the RTR session.
+    rtr_state: State of the rtr session (up/down).
+    update: Timestamp of the last update.
+    vrp_diff: The number of VRPs which were seen in lhs at least visibility_seconds ago not in rhs.
+    </pre>
+</body>
+</html>


### PR DESCRIPTION
I added documentation as the HTML index page instead of a 404. Since the rtrmon endpoints are not used often it is hard to remember the URL of the diff endpoint. In the end a user needs to document this in internal documentation - or go to the rtrmon docs while investigating an alert. 

I think adding this here is a small quality of life feature for users.

In my opinion the templating is optional, but it is definitely slightly nicer.
<img width="884" alt="Screenshot 2022-07-11 at 12 17 49" src="https://user-images.githubusercontent.com/199058/178243070-9236e943-ac96-4911-8c5c-4036f3cbdd69.png">

