### PR TITLE
Grace period for diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ vet:
 test:
 	go test -v github.com/bgp/stayrtr/lib
 	go test -v github.com/bgp/stayrtr/prefixfile
+	go test -v github.com/bgp/stayrtr/cmd/rtrmon
+	go test -v github.com/bgp/stayrtr/cmd/stayrtr
 
 .PHONY: prepare
 prepare:

--- a/cmd/rtrmon/rtrmon.go
+++ b/cmd/rtrmon/rtrmon.go
@@ -294,7 +294,7 @@ func (c *Client) Start(id int, ch chan int) {
 					serverKeyHash := ssh.FingerprintSHA256(key)
 					if c.ValidateSSH {
 						if serverKeyHash != fmt.Sprintf("SHA256:%v", c.SSHServerKey) {
-							return errors.New(fmt.Sprintf("Server key hash %v is different than expected key hash SHA256:%v", serverKeyHash, c.SSHServerKey))
+							return fmt.Errorf("server key hash %v is different than expected key hash SHA256:%v", serverKeyHash, c.SSHServerKey)
 						}
 					}
 					log.Infof("%d: Connected to server %v via ssh. Fingerprint: %v", id, remote.String(), serverKeyHash)

--- a/cmd/rtrmon/rtrmon_test.go
+++ b/cmd/rtrmon/rtrmon_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/bgp/stayrtr/prefixfile"
+)
+
+func TestBuildNewVrpMap_expiry(t *testing.T) {
+	stuff := testData()
+	now := time.Now()
+	log := log.WithField("client", "TestBuildNewVrpMap_expiry")
+
+	res, inGracePeriod := BuildNewVrpMap(log, make(VRPMap), stuff, now)
+	if inGracePeriod != 0 {
+		t.Errorf("Initial build does not have objects in grace period")
+	}
+
+	_, inGracePeriodPreserved := BuildNewVrpMap(log, res, []prefixfile.VRPJson{}, now.Add(time.Minute*10))
+	if inGracePeriodPreserved != len(res) {
+		t.Errorf("All objects are in grace period")
+	}
+
+	// Objects are kept in grace period
+	// 1s before grace period ends
+	t1 := now.Add(*GracePeriod).Add(-time.Second * 1)
+	res, inGracePeriod = BuildNewVrpMap(log, res, []prefixfile.VRPJson{}, t1)
+
+	assertLastSeenMatchesTimeCount(t, res, t1, 0)
+	assertLastSeenMatchesTimeCount(t, res, now, len(stuff))
+	if inGracePeriod != len(stuff) {
+		t.Errorf("All objects should be in grace period. Expected: %d, actual: %d", len(stuff), inGracePeriod)
+	}
+
+	// 1s after grace period ends, they are removed
+	res, inGracePeriod = BuildNewVrpMap(log, res, []prefixfile.VRPJson{}, now.Add(*GracePeriod).Add(time.Second*1))
+	if len(res) != 0 {
+		t.Errorf("Expected no objects to be left after grace period, actual: %d", len(res))
+	}
+	if inGracePeriod != 0 {
+		t.Errorf("Expected 0 objects in grace period, actual: %d", inGracePeriod)
+	}
+}
+
+func TestBuildNewVrpMap_firsSeen_lastSeen(t *testing.T) {
+	t0 := time.Now()
+	log := log.WithField("client", "TestBuildNewVrpMap_firstSeen_lastSeen")
+	stuff := testData()
+
+	var res, _ = BuildNewVrpMap(log, make(VRPMap), stuff, t0)
+
+	// All have firstSeen + lastSeen equal to t0
+	assertFirstSeenMatchesTimeCount(t, res, t0, len(stuff))
+	assertLastSeenMatchesTimeCount(t, res, t0, len(stuff))
+
+	// Supply same data again later
+	t1 := t0.Add(time.Minute * 10)
+	res, _ = BuildNewVrpMap(log, res, stuff, t1)
+
+	// FirstSeen is constant, LastSeen gets updated
+	assertFirstSeenMatchesTimeCount(t, res, t0, len(stuff))
+	assertLastSeenMatchesTimeCount(t, res, t1, len(stuff))
+
+	// Supply one new VRP, expect one at new time, others at old time
+	otherStuff := []prefixfile.VRPJson{
+		{
+			Prefix: "2001:DB8::/32",
+			Length: 48,
+			ASN:    65536,
+			TA:     "testrir",
+		},
+	}
+	t2 := t1.Add(time.Minute * 10)
+	res, _ = BuildNewVrpMap(log, res, otherStuff, t2)
+
+	// LastSeen gets updated just for the new item
+	assertFirstSeenMatchesTimeCount(t, res, t0, len(stuff))
+	assertLastSeenMatchesTimeCount(t, res, t1, len(stuff))
+
+	assertFirstSeenMatchesTimeCount(t, res, t2, len(otherStuff))
+	assertLastSeenMatchesTimeCount(t, res, t2, len(otherStuff))
+}
+
+func assertFirstSeenMatchesTimeCount(t *testing.T, vrps VRPMap, pit time.Time, expected int) {
+	actual := countMatches(vrps, func(vrp *VRPJsonSimple) bool { return vrp.FirstSeen == pit.Unix() })
+	if actual != expected {
+		t.Errorf("Expected %d VRPs to have FirstSeen of %v, actual: %d", expected, pit, actual)
+	}
+}
+
+func assertLastSeenMatchesTimeCount(t *testing.T, vrps VRPMap, pit time.Time, expected int) {
+	actual := countMatches(vrps, func(vrp *VRPJsonSimple) bool { return vrp.LastSeen == pit.Unix() })
+	if actual != expected {
+		t.Errorf("Expected %d VRPs to have LastSeen of %v, actual: %d", expected, pit, actual)
+	}
+}
+
+type extractor func(object *VRPJsonSimple) bool
+
+func countMatches(vrps VRPMap, e extractor) int {
+	matches := 0
+	for _, entry := range vrps {
+		if e(entry) {
+			matches++
+		}
+	}
+
+	return matches
+}
+
+func testData() []prefixfile.VRPJson {
+	var stuff []prefixfile.VRPJson
+	stuff = append(stuff,
+		prefixfile.VRPJson{
+			Prefix: "192.168.0.0/24",
+			Length: 24,
+			ASN:    65537,
+			TA:     "testrir",
+		},
+		prefixfile.VRPJson{
+			Prefix: "192.168.0.0/24",
+			Length: 24,
+			ASN:    65536,
+			TA:     "testrir",
+		},
+		prefixfile.VRPJson{
+			Prefix: "2001:db8::/32",
+			Length: 33,
+			ASN:    "AS64496",
+			TA:     "testrir",
+		},
+		prefixfile.VRPJson{
+			Prefix: "192.168.1.0/24",
+			Length: 25,
+			ASN:    64497,
+			TA:     "testrir",
+		},
+	)
+
+	return stuff
+}


### PR DESCRIPTION
When a VRP disappears from one input it may not disappear from the other input at the same time. Because a VRP is not present in one input, that has been present in the other input for a long time, an alert may fire immediately if the other source does not get updated before that alert fires.

This commits adds a grace period during which elements that disappear from one source do not cause alerts (yet).