### PR TITLE
Fixed SSH client key validation

### DIFF
--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -684,7 +684,7 @@ func run() error {
 						if k == "" {
 							continue
 						}
-						if strings.HasPrefix(fmt.Sprintf("%v %v", key.Type(), keyBase64), k) {
+						if strings.HasPrefix(k, fmt.Sprintf("%v %v", key.Type(), keyBase64)) {
 							log.Infof("Connected (ssh-key): %v/%v with key %v %v (matched with line %v)",
 								conn.User(), conn.RemoteAddr(), key.Type(), keyBase64, i+1)
 							noKeys = true


### PR DESCRIPTION
The `strings.HasPrefix()` call was used with flipped argument order, allowing to match incomplete rows in the `authorized_keys` file to any key matching that prefix. In worst case, a line like

`ecdsa-sha2-nistp256`

with no key at all would match all keys of that type.

On the other hand, when the key was followed by a comment (or anything else) as is common in `authorized_keys` files, it wasn't matched at all.