### PR TITLE
Avoid false positives in rtrmon when VRPs are removed

### DIFF
--- a/cmd/rtrmon/rtrmon.go
+++ b/cmd/rtrmon/rtrmon.go
@@ -395,6 +395,7 @@ func BuildNewVrpMap(log *log.Entry, currentVrps VRPMap, newVrps []prefixfile.VRP
 		firstSeen := tCurrentUpdate
 		currentEntry, ok := currentVrps[key]
 		if ok && currentEntry.Visible {
+			// VRP is still visible, so keep the existing `FirstSeen`.
 			firstSeen = currentEntry.FirstSeen
 		}
 

--- a/cmd/rtrmon/rtrmon.go
+++ b/cmd/rtrmon/rtrmon.go
@@ -351,8 +351,9 @@ func (c *Client) Start(id int, ch chan int) {
 				}
 
 				updatedVrpMap, inGracePeriod = BuildNewVrpMap(log.WithField("client", c.id), c.vrps, decoded.Data, tCurrentUpdate)
-				VRPInGracePeriod.With(prometheus.Labels{"url": c.Path}).Set(float64(inGracePeriod))
 			}
+
+			VRPInGracePeriod.With(prometheus.Labels{"url": c.Path}).Set(float64(inGracePeriod))
 
 			c.compLock.Lock()
 			c.vrps = updatedVrpMap

--- a/cmd/rtrmon/rtrmon.go
+++ b/cmd/rtrmon/rtrmon.go
@@ -436,13 +436,13 @@ func UpdateCurrentVrpMap(log *log.Entry, currentVrps VRPMap, now time.Time) (VRP
 			continue
 		}
 
-		updated := *vrp
-		if updated.Visible {
-			updated.LastSeen = tCurrentUpdate
+		copy := *vrp
+		if copy.Visible {
+			copy.LastSeen = tCurrentUpdate
 		} else {
 			inGracePeriod++
 		}
-		res[key] = &updated
+		res[key] = &copy
 	}
 
 	return res, inGracePeriod

--- a/cmd/rtrmon/rtrmon.go
+++ b/cmd/rtrmon/rtrmon.go
@@ -337,8 +337,8 @@ func (c *Client) Start(id int, ch chan int) {
 				continue
 			}
 
-			var updatedVrpMap VRPMap;
-			var inGracePeriod int;
+			var updatedVrpMap VRPMap
+			var inGracePeriod int
 			tCurrentUpdate := time.Now().UTC()
 			if statusCode == 304 {
 				updatedVrpMap, inGracePeriod = UpdateCurrentVrpMap(log.WithField("client", c.id), c.vrps, tCurrentUpdate)
@@ -354,10 +354,10 @@ func (c *Client) Start(id int, ch chan int) {
 				VRPInGracePeriod.With(prometheus.Labels{"url": c.Path}).Set(float64(inGracePeriod))
 			}
 
-				c.compLock.Lock()
-				c.vrps = updatedVrpMap
-				c.lastUpdate = tCurrentUpdate
-				c.compLock.Unlock()
+			c.compLock.Lock()
+			c.vrps = updatedVrpMap
+			c.lastUpdate = tCurrentUpdate
+			c.compLock.Unlock()
 			if ch != nil {
 				ch <- id
 			}
@@ -431,7 +431,7 @@ func UpdateCurrentVrpMap(log *log.Entry, currentVrps VRPMap, now time.Time) (VRP
 
 	for key, vrp := range currentVrps {
 		if !vrp.Visible && vrp.LastSeen < gracePeriodEnds {
-			continue;
+			continue
 		}
 
 		updated := *vrp
@@ -440,7 +440,7 @@ func UpdateCurrentVrpMap(log *log.Entry, currentVrps VRPMap, now time.Time) (VRP
 		} else {
 			inGracePeriod++
 		}
-		res[key] = &updated;
+		res[key] = &updated
 	}
 
 	return res, inGracePeriod
@@ -620,11 +620,11 @@ func NewComparator(c1, c2 *Client) *Comparator {
 }
 
 func isDefinitelyVisible(vrp *VRPJsonSimple, thresholdTimestamp int64) bool {
-	return vrp != nil && vrp.Visible && vrp.FirstSeen <= thresholdTimestamp;
+	return vrp != nil && vrp.Visible && vrp.FirstSeen <= thresholdTimestamp
 }
 
 func isDefinitelyNotVisisble(vrp *VRPJsonSimple, thresholdTimestamp int64) bool {
-	return vrp == nil || (!vrp.Visible && vrp.LastSeen <= thresholdTimestamp);
+	return vrp == nil || (!vrp.Visible && vrp.LastSeen <= thresholdTimestamp)
 }
 
 func countUnmatched(vrps VRPMap, others VRPMap, thresholdTimestamp int64) float64 {
@@ -665,7 +665,7 @@ func VRPArray(a VRPMap) []*VRPJsonSimple {
 	for _, vrp := range a {
 		result = append(result, vrp)
 	}
-	return result;
+	return result
 }
 
 type diffMetadata struct {
@@ -886,7 +886,7 @@ func main() {
 	lvl, _ := log.ParseLevel(*LogLevel)
 	log.SetLevel(lvl)
 
-	highestVisibilityThreshold := time.Second * time.Duration(visibilityThresholds[len(visibilityThresholds) - 1])
+	highestVisibilityThreshold := time.Second * time.Duration(visibilityThresholds[len(visibilityThresholds)-1])
 	if highestVisibilityThreshold > *GracePeriod {
 		log.Warnf("Highest visibility threshold %v greater than grace period %v, adjusting grace period", highestVisibilityThreshold, GracePeriod)
 		*GracePeriod = highestVisibilityThreshold

--- a/cmd/rtrmon/rtrmon_test.go
+++ b/cmd/rtrmon/rtrmon_test.go
@@ -55,14 +55,16 @@ func TestBuildNewVrpMap_firsSeen_lastSeen(t *testing.T) {
 	// All have firstSeen + lastSeen equal to t0
 	assertFirstSeenMatchesTimeCount(t, res, t0, len(stuff))
 	assertLastSeenMatchesTimeCount(t, res, t0, len(stuff))
+	assertVisibleMatchesTimeCount(t, res, len(stuff))
 
 	// Supply same data again later
 	t1 := t0.Add(time.Minute * 10)
 	res, _ = BuildNewVrpMap(log, res, stuff, t1)
 
-	// FirstSeen is constant, LastSeen gets updated
+	// FirstSeen is constant, LastSeen gets updated, none removed
 	assertFirstSeenMatchesTimeCount(t, res, t0, len(stuff))
 	assertLastSeenMatchesTimeCount(t, res, t1, len(stuff))
+	assertVisibleMatchesTimeCount(t, res, len(stuff))
 
 	// Supply one new VRP, expect one at new time, others at old time
 	otherStuff := []prefixfile.VRPJson{
@@ -82,6 +84,7 @@ func TestBuildNewVrpMap_firsSeen_lastSeen(t *testing.T) {
 
 	assertFirstSeenMatchesTimeCount(t, res, t2, len(otherStuff))
 	assertLastSeenMatchesTimeCount(t, res, t2, len(otherStuff))
+	assertVisibleMatchesTimeCount(t, res, len(otherStuff))
 }
 
 func assertFirstSeenMatchesTimeCount(t *testing.T, vrps VRPMap, pit time.Time, expected int) {
@@ -95,6 +98,13 @@ func assertLastSeenMatchesTimeCount(t *testing.T, vrps VRPMap, pit time.Time, ex
 	actual := countMatches(vrps, func(vrp *VRPJsonSimple) bool { return vrp.LastSeen == pit.Unix() })
 	if actual != expected {
 		t.Errorf("Expected %d VRPs to have LastSeen of %v, actual: %d", expected, pit, actual)
+	}
+}
+
+func assertVisibleMatchesTimeCount(t *testing.T, vrps VRPMap, expected int) {
+	actual := countMatches(vrps, func(vrp *VRPJsonSimple) bool { return vrp.Visible })
+	if actual != expected {
+		t.Errorf("Expected %d VRPs to be visible, actual: %d", expected, actual)
 	}
 }
 


### PR DESCRIPTION
Track visibility of VRPs on both sides and only consider them different when the visibility does not match based on the visibility thresholds.

Also update the results even when the sources have not been modified, since the thresholds may have changed in the meantime as time passes.