### PR TITLE
Remove the AFI dependency for ASPA

### DIFF
--- a/cmd/rtrdump/rtrdump.go
+++ b/cmd/rtrdump/rtrdump.go
@@ -117,22 +117,14 @@ func (c *Client) HandlePDU(cs *rtr.ClientSession, pdu rtr.PDU) {
 
 	case *rtr.PDUASPA:
 		if c.Data.ASPA == nil {
-			c.Data.ASPA = &prefixfile.ProviderAuthorizationsJson{
-				IPv4: make([]prefixfile.ASPAJson, 0),
-				IPv6: make([]prefixfile.ASPAJson, 0),
-			}
+			c.Data.ASPA = make([]prefixfile.ASPAJson, 0)
 		}
 		aj := prefixfile.ASPAJson{
 			CustomerAsid: pdu.CustomerASNumber,
 			Providers:    pdu.ProviderASNumbers,
 		}
 
-		switch pdu.AFIFlags {
-		case rtr.AFI_IPv4:
-			c.Data.ASPA.IPv4 = append(c.Data.ASPA.IPv4, aj)
-		case rtr.AFI_IPv6:
-			c.Data.ASPA.IPv6 = append(c.Data.ASPA.IPv6, aj)
-		}
+		c.Data.ASPA = append(c.Data.ASPA, aj)
 
 		if *LogDataPDU {
 			log.Debugf("Received: %v", pdu)

--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -313,13 +313,7 @@ func processData(vrplistjson []prefixfile.VRPJson,
 		})
 	}
 
-	aspalist = handleASPAList(aspajson, NowUnix, aspalist)
-
-	return vrplist, brklist, aspalist, countv4 + countv6, countv4, countv6
-}
-
-func handleASPAList(list []prefixfile.ASPAJson, NowUnix int64, aspalist []rtr.VAP) []rtr.VAP {
-	for _, v := range list {
+	for _, v := range aspajson {
 		if v.Expires != nil {
 			if NowUnix > *v.Expires {
 				continue
@@ -337,7 +331,8 @@ func handleASPAList(list []prefixfile.ASPAJson, NowUnix int64, aspalist []rtr.VA
 			Providers:   v.Providers,
 		})
 	}
-	return aspalist
+
+	return vrplist, brklist, aspalist, countv4 + countv6, countv4, countv6
 }
 
 type IdenticalFile struct {

--- a/lib/server.go
+++ b/lib/server.go
@@ -979,7 +979,6 @@ func (brk *BgpsecKey) GetFlag() uint8 {
 
 type VAP struct {
 	Flags       uint8
-	AFI         uint8
 	CustomerASN uint32
 	Providers   []uint32
 }
@@ -989,11 +988,11 @@ func (vap *VAP) Type() string {
 }
 
 func (vap *VAP) String() string {
-	return fmt.Sprintf("ASPA AS%v -> AFI %d, Providers: %v", vap.CustomerASN, vap.AFI, vap.Providers)
+	return fmt.Sprintf("ASPA AS%v -> Providers: %v", vap.CustomerASN, vap.Providers)
 }
 
 func (vap *VAP) HashKey() string {
-	return fmt.Sprintf("%v-%x-%v", vap.CustomerASN, vap.AFI, vap.Providers)
+	return fmt.Sprintf("%v-%v", vap.CustomerASN, vap.Providers)
 }
 
 func (r1 *VAP) Equals(r2 SendableData) bool {
@@ -1008,7 +1007,6 @@ func (r1 *VAP) Equals(r2 SendableData) bool {
 func (vap *VAP) Copy() SendableData {
 	cop := VAP{
 		CustomerASN: vap.CustomerASN,
-		AFI:         vap.AFI,
 		Flags:       vap.Flags,
 		Providers:   make([]uint32, 0),
 	}
@@ -1120,15 +1118,24 @@ func (c *Client) SendData(sd SendableData) {
 			return
 		}
 
-		pdu := &PDUASPA{
+		pdu4 := &PDUASPA{
 			Version:           c.version,
 			Flags:             t.Flags,
-			AFIFlags:          t.AFI,
+			AFIFlags:          AFI_IPv4,
 			ProviderASCount:   uint16(len(t.Providers)),
 			CustomerASNumber:  t.CustomerASN,
 			ProviderASNumbers: t.Providers,
 		}
-		c.SendPDU(pdu)
+		pdu6 := &PDUASPA{
+			Version:           c.version,
+			Flags:             t.Flags,
+			AFIFlags:          AFI_IPv6,
+			ProviderASCount:   uint16(len(t.Providers)),
+			CustomerASNumber:  t.CustomerASN,
+			ProviderASNumbers: t.Providers,
+		}
+		c.SendPDU(pdu4)
+		c.SendPDU(pdu6)
 	}
 }
 

--- a/prefixfile/prefixfile.go
+++ b/prefixfile/prefixfile.go
@@ -36,7 +36,7 @@ type VRPList struct {
 	Metadata   MetaData                    `json:"metadata,omitempty"`
 	Data       []VRPJson                   `json:"roas"` // for historical reasons this is called 'roas', but should've been called vrps
 	BgpSecKeys []BgpSecKeyJson             `json:"bgpsec_keys,omitempty"`
-	ASPA       *ProviderAuthorizationsJson `json:"provider_authorizations,omitempty"`
+	ASPA       []ASPAJson                  `json:"aspas,omitempty"`
 }
 
 type BgpSecKeyJson struct {
@@ -53,11 +53,6 @@ type BgpSecKeyJson struct {
 }
 
 // ASPA
-type ProviderAuthorizationsJson struct {
-	IPv4 []ASPAJson `json:"ipv4"`
-	IPv6 []ASPAJson `json:"ipv6"`
-}
-
 type ASPAJson struct {
 	CustomerAsid uint32   `json:"customer_asid"`
 	Expires      *int64   `json:"expires,omitempty"`

--- a/prefixfile/slurm_test.go
+++ b/prefixfile/slurm_test.go
@@ -241,8 +241,8 @@ func TestSlurmEndToEnd(t *testing.T) {
 		panic(err)
 	}
 
-	finalVRP, _, finalASPA6, finalBgpsec :=
-		config.FilterAssert(vrplist.Data, vrplist.ASPA.IPv4, vrplist.ASPA.IPv6, vrplist.BgpSecKeys, nil)
+	finalVRP, finalASPA, finalBgpsec :=
+		config.FilterAssert(vrplist.Data, vrplist.ASPA, vrplist.BgpSecKeys, nil)
 
 	foundAssertVRP := false
 	for _, vrps := range finalVRP {
@@ -259,7 +259,7 @@ func TestSlurmEndToEnd(t *testing.T) {
 	}
 
 	foundAssertVAP := false
-	for _, vaps := range finalASPA6 {
+	for _, vaps := range finalASPA {
 		if vaps.CustomerAsid == 64499 {
 			foundAssertVAP = true
 		}


### PR DESCRIPTION
The AFI was removed from the ASPA profile so don't expect it anymore. Now RTR is still using an old idea of ASPA profile so there just duplicate the object once for IPv4 and once for IPv6. At some points SIDROPS may finally fix this but for now this allows to export ASPA objects that follow the rpki-client JSON (which no longer has the AFI in the ASPA table).

I'm not certain about the changes to slurm but I think it should be fine.
With this stayrtr is able to distribute the ASPA records from the default cache file.