### PR TITLE
Use a int64 for Unix time to make this code 2038 proof.

### DIFF
--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -208,7 +208,7 @@ func processData(vrplistjson []prefixfile.VRPJson,
 	// grab the current time every time it's invoked, time calls can be slow on
 	// some platforms, so lets just get the unix time when we start and use that
 	// to compare it all
-	NowUnix := time.Now().UTC().Unix()
+	NowUnix := time.Now().Unix()
 
 	var vrplist []rtr.VRP
 	var brklist = make([]rtr.BgpsecKey, 0)
@@ -235,7 +235,7 @@ func processData(vrplistjson []prefixfile.VRPJson,
 		if v.Expires != nil {
 			// Prevent stale VRPs from being considered
 			// https://github.com/bgp/stayrtr/issues/15
-			if int(NowUnix) > int(*v.Expires) {
+			if NowUnix > *v.Expires {
 				continue
 			}
 		}
@@ -297,7 +297,7 @@ func processData(vrplistjson []prefixfile.VRPJson,
 		if v.Expires != nil {
 			// Prevent stale VRPs from being considered
 			// https://github.com/bgp/stayrtr/issues/15
-			if int(NowUnix) > int(*v.Expires) {
+			if NowUnix > *v.Expires {
 				continue
 			}
 		}
@@ -325,7 +325,7 @@ func processData(vrplistjson []prefixfile.VRPJson,
 func handleASPAList(list []prefixfile.ASPAJson, NowUnix int64, aspalist []rtr.VAP, AFI uint8) []rtr.VAP {
 	for _, v := range list {
 		if v.Expires != nil {
-			if int(NowUnix) > int(*v.Expires) {
+			if NowUnix > *v.Expires {
 				continue
 			}
 		}
@@ -377,7 +377,7 @@ func (s *state) updateFromNewState() error {
 
 	buildtime, err := time.Parse(time.RFC3339, s.lastdata.Metadata.Buildtime)
 	if s.lastdata.Metadata.GeneratedUnix != nil {
-		buildtime, err = time.Unix(int64(*s.lastdata.Metadata.GeneratedUnix), 0), nil
+		buildtime, err = time.Unix(*s.lastdata.Metadata.GeneratedUnix, 0), nil
 	}
 	if s.checktime {
 		if err != nil {
@@ -422,7 +422,7 @@ func (s *state) reloadFromCurrentState() error {
 
 	buildtime, err := time.Parse(time.RFC3339, s.lastdata.Metadata.Buildtime)
 	if s.lastdata.Metadata.GeneratedUnix != nil {
-		buildtime, err = time.Unix(int64(*s.lastdata.Metadata.GeneratedUnix), 0), nil
+		buildtime, err = time.Unix(*s.lastdata.Metadata.GeneratedUnix, 0), nil
 	}
 	if s.checktime {
 		if err != nil {

--- a/cmd/stayrtr/stayrtr_test.go
+++ b/cmd/stayrtr/stayrtr_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestProcessData(t *testing.T) {
 	var stuff []prefixfile.VRPJson
-	NowUnix := int(time.Now().Unix())
-	ExpiredTime := 1337
+	NowUnix := time.Now().Unix()
+	ExpiredTime := int64(1337)
 
 	stuff = append(stuff,
 		prefixfile.VRPJson{
@@ -158,8 +158,8 @@ func TestJson(t *testing.T) {
 		t.Errorf("Unable to decode json: %v", err)
 	}
 
-	Ex1 := 1627568318
-	Ex2 := 1627575699
+	Ex1 := int64(1627568318)
+	Ex2 := int64(1627575699)
 
 	want := (&prefixfile.VRPList{
 		Metadata: prefixfile.MetaData{

--- a/prefixfile/prefixfile.go
+++ b/prefixfile/prefixfile.go
@@ -13,13 +13,15 @@ type VRPJson struct {
 	Length  uint8       `json:"maxLength"`
 	ASN     interface{} `json:"asn"`
 	TA      string      `json:"ta,omitempty"`
-	Expires *int        `json:"expires,omitempty"`
+	Expires *int64      `json:"expires,omitempty"`
 }
 
 type MetaData struct {
 	Counts        int    `json:"vrps"`
+	CountASPAs    int    `json:"aspas"`
+	CountBgpSecKeys int  `json:"aspas"`
 	Buildtime     string `json:"buildtime,omitempty"`
-	GeneratedUnix *int   `json:"generated,omitempty"`
+	GeneratedUnix *int64 `json:"generated,omitempty"`
 }
 
 func (md MetaData) GetBuildTime() time.Time {
@@ -39,7 +41,7 @@ type VRPList struct {
 
 type BgpSecKeyJson struct {
 	Asn     uint32  `json:"asn"`
-	Expires *uint32 `json:"expires,omitempty"`
+	Expires *int64  `json:"expires,omitempty"`
 	Ta      string  `json:"ta,omitempty"`
 
 	// Base32 encoded, but encoding/json handles this for us
@@ -58,7 +60,7 @@ type ProviderAuthorizationsJson struct {
 
 type ASPAJson struct {
 	CustomerAsid uint32   `json:"customer_asid"`
-	Expires      *uint32  `json:"expires,omitempty"`
+	Expires      *int64   `json:"expires,omitempty"`
 	Providers    []uint32 `json:"providers"`
 }
 


### PR DESCRIPTION
Casting `Time.Unix()` down to an `int` is going to be a problem "soon".
Just use int64 in the JSON structs this will move the issue out to a generation that hopefully no longer suffers from using golang, JSON and especially RPKI.