### PR TITLE
Naming is hard

### DIFF
--- a/cmd/rtrdump/rtrdump.go
+++ b/cmd/rtrdump/rtrdump.go
@@ -69,7 +69,7 @@ var (
 )
 
 type Client struct {
-	Data prefixfile.VRPList
+	Data prefixfile.RPKIList
 
 	InitSerial bool
 	Serial     uint32
@@ -84,7 +84,7 @@ func (c *Client) HandlePDU(cs *rtr.ClientSession, pdu rtr.PDU) {
 			ASN:    uint32(pdu.ASN),
 			Length: pdu.MaxLen,
 		}
-		c.Data.Data = append(c.Data.Data, rj)
+		c.Data.ROA = append(c.Data.ROA, rj)
 		c.Data.Metadata.Counts++
 
 		if *LogDataPDU {
@@ -96,7 +96,7 @@ func (c *Client) HandlePDU(cs *rtr.ClientSession, pdu rtr.PDU) {
 			ASN:    uint32(pdu.ASN),
 			Length: pdu.MaxLen,
 		}
-		c.Data.Data = append(c.Data.Data, rj)
+		c.Data.ROA = append(c.Data.ROA, rj)
 		c.Data.Metadata.Counts++
 
 		if *LogDataPDU {
@@ -117,9 +117,9 @@ func (c *Client) HandlePDU(cs *rtr.ClientSession, pdu rtr.PDU) {
 
 	case *rtr.PDUASPA:
 		if c.Data.ASPA == nil {
-			c.Data.ASPA = make([]prefixfile.ASPAJson, 0)
+			c.Data.ASPA = make([]prefixfile.VAPJson, 0)
 		}
-		aj := prefixfile.ASPAJson{
+		aj := prefixfile.VAPJson{
 			CustomerAsid: pdu.CustomerASNumber,
 			Providers:    pdu.ProviderASNumbers,
 		}
@@ -182,9 +182,9 @@ func main() {
 	}
 
 	client := &Client{
-		Data: prefixfile.VRPList{
+		Data: prefixfile.RPKIList{
 			Metadata: prefixfile.MetaData{},
-			Data:     make([]prefixfile.VRPJson, 0),
+			ROA:     make([]prefixfile.VRPJson, 0),
 		},
 		InitSerial: *InitSerial,
 		Serial:     uint32(*Serial),

--- a/cmd/rtrmon/rtrmon.go
+++ b/cmd/rtrmon/rtrmon.go
@@ -199,11 +199,11 @@ func (t *thresholds) Set(value string) error {
 	return nil
 }
 
-func decodeJSON(data []byte) (*prefixfile.VRPList, error) {
+func decodeJSON(data []byte) (*prefixfile.RPKIList, error) {
 	buf := bytes.NewBuffer(data)
 	dec := json.NewDecoder(buf)
 
-	var vrplistjson prefixfile.VRPList
+	var vrplistjson prefixfile.RPKIList
 	err := dec.Decode(&vrplistjson)
 	return &vrplistjson, err
 }
@@ -369,8 +369,8 @@ func (c *Client) Start(id int, ch chan int) {
 //   * contains all the VRPs in newVRPs
 //   * keeps the firstSeen value for VRPs already in the old map
 //   * keeps elements around for GracePeriod after they are not in the input.
-func BuildNewVrpMap(log *log.Entry, currentVrps VRPMap, pfxFile *prefixfile.VRPList, now time.Time) (VRPMap, int) {
-	var newVrps = pfxFile.Data
+func BuildNewVrpMap(log *log.Entry, currentVrps VRPMap, pfxFile *prefixfile.RPKIList, now time.Time) (VRPMap, int) {
+	var newVrps = pfxFile.ROA
 	tCurrentUpdate := now.Unix()
 	res := make(VRPMap)
 

--- a/cmd/rtrmon/rtrmon_test.go
+++ b/cmd/rtrmon/rtrmon_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestBuildNewVrpMap_expiry(t *testing.T) {
 	stuff := testDataFile()
-	emptyFile := &prefixfile.VRPList{
+	emptyFile := &prefixfile.RPKIList{
 		Metadata:   prefixfile.MetaData{},
-		Data:       []prefixfile.VRPJson{},
+		ROA:        []prefixfile.VRPJson{},
 		BgpSecKeys: []prefixfile.BgpSecKeyJson{},
 	}
 
@@ -36,9 +36,9 @@ func TestBuildNewVrpMap_expiry(t *testing.T) {
 	res, inGracePeriod = BuildNewVrpMap(log, res, emptyFile, t1)
 
 	assertLastSeenMatchesTimeCount(t, res, t1, 0)
-	assertLastSeenMatchesTimeCount(t, res, now, len(stuff.Data))
-	if inGracePeriod != len(stuff.Data) {
-		t.Errorf("All objects should be in grace period. Expected: %d, actual: %d", len(stuff.Data), inGracePeriod)
+	assertLastSeenMatchesTimeCount(t, res, now, len(stuff.ROA))
+	if inGracePeriod != len(stuff.ROA) {
+		t.Errorf("All objects should be in grace period. Expected: %d, actual: %d", len(stuff.ROA), inGracePeriod)
 	}
 
 	// 1s after grace period ends, they are removed
@@ -59,18 +59,18 @@ func TestBuildNewVrpMap_firsSeen_lastSeen(t *testing.T) {
 	var res, _ = BuildNewVrpMap(log, make(VRPMap), stuff, t0)
 
 	// All have firstSeen + lastSeen equal to t0
-	assertFirstSeenMatchesTimeCount(t, res, t0, len(stuff.Data))
-	assertLastSeenMatchesTimeCount(t, res, t0, len(stuff.Data))
-	assertVisibleMatchesTimeCount(t, res, len(stuff.Data))
+	assertFirstSeenMatchesTimeCount(t, res, t0, len(stuff.ROA))
+	assertLastSeenMatchesTimeCount(t, res, t0, len(stuff.ROA))
+	assertVisibleMatchesTimeCount(t, res, len(stuff.ROA))
 
 	// Supply same data again later
 	t1 := t0.Add(time.Minute * 10)
 	res, _ = BuildNewVrpMap(log, res, stuff, t1)
 
 	// FirstSeen is constant, LastSeen gets updated, none removed
-	assertFirstSeenMatchesTimeCount(t, res, t0, len(stuff.Data))
-	assertLastSeenMatchesTimeCount(t, res, t1, len(stuff.Data))
-	assertVisibleMatchesTimeCount(t, res, len(stuff.Data))
+	assertFirstSeenMatchesTimeCount(t, res, t0, len(stuff.ROA))
+	assertLastSeenMatchesTimeCount(t, res, t1, len(stuff.ROA))
+	assertVisibleMatchesTimeCount(t, res, len(stuff.ROA))
 
 	// Supply one new VRP, expect one at new time, others at old time
 	otherStuff := []prefixfile.VRPJson{
@@ -81,17 +81,17 @@ func TestBuildNewVrpMap_firsSeen_lastSeen(t *testing.T) {
 			TA:     "testrir",
 		},
 	}
-	otherStuffFile := prefixfile.VRPList{
+	otherStuffFile := prefixfile.RPKIList{
 		Metadata:   prefixfile.MetaData{},
-		Data:       otherStuff,
+		ROA:        otherStuff,
 		BgpSecKeys: []prefixfile.BgpSecKeyJson{},
 	}
 	t2 := t1.Add(time.Minute * 10)
 	res, _ = BuildNewVrpMap(log, res, &otherStuffFile, t2)
 
 	// LastSeen gets updated just for the new item
-	assertFirstSeenMatchesTimeCount(t, res, t0, len(stuff.Data))
-	assertLastSeenMatchesTimeCount(t, res, t1, len(stuff.Data))
+	assertFirstSeenMatchesTimeCount(t, res, t0, len(stuff.ROA))
+	assertLastSeenMatchesTimeCount(t, res, t1, len(stuff.ROA))
 
 	assertFirstSeenMatchesTimeCount(t, res, t2, len(otherStuff))
 	assertLastSeenMatchesTimeCount(t, res, t2, len(otherStuff))
@@ -164,10 +164,10 @@ func testData() []prefixfile.VRPJson {
 	return stuff
 }
 
-func testDataFile() *prefixfile.VRPList {
-	stuff := prefixfile.VRPList{
+func testDataFile() *prefixfile.RPKIList {
+	stuff := prefixfile.RPKIList{
 		Metadata:   prefixfile.MetaData{},
-		Data:       testData(),
+		ROA:        testData(),
 		BgpSecKeys: []prefixfile.BgpSecKeyJson{},
 	}
 	return &stuff

--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -424,8 +424,8 @@ func (s *state) reloadFromCurrentState() error {
 	}
 
 	vrps, brks, vaps, count, countv4, countv6 := processData(vrpsjson, bgpsecjson, aspajson)
-	if s.server.CountVRPs() != count {
-		log.Infof("New update to old state (%v uniques, %v total prefixes). (old %v - new %v)", len(vrps), count, s.server.CountVRPs(), count)
+	if s.server.CountSDs() != count {
+		log.Infof("New update to old state (%v uniques, %v total prefixes). (old %v - new %v)", len(vrps), count, s.server.CountSDs(), count)
 		return s.applyUpdateFromNewState(vrps, brks, vaps, sessid, vrpsjson, bgpsecjson, aspajson, countv4, countv6)
 	}
 	return nil

--- a/cmd/stayrtr/stayrtr_test.go
+++ b/cmd/stayrtr/stayrtr_test.go
@@ -156,12 +156,12 @@ func TestJson(t *testing.T) {
 	Ex1 := int64(1627568318)
 	Ex2 := int64(1627575699)
 
-	want := (&prefixfile.VRPList{
+	want := (&prefixfile.RPKIList{
 		Metadata: prefixfile.MetaData{
 			Counts:    2,
 			Buildtime: "2021-07-27T18:56:02Z",
 		},
-		Data: []prefixfile.VRPJson{
+		ROA:  []prefixfile.VRPJson{
 			{Prefix: "1.0.0.0/24",
 				Length:  24,
 				ASN:     float64(13335),

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -16,7 +16,7 @@ var (
 )
 
 type TestClient struct {
-	Data prefixfile.VRPList
+	Data prefixfile.RPKIList
 
 	InitSerial bool
 	Serial     uint32
@@ -34,9 +34,9 @@ func getBasicClientConguration(version int) ClientConfiguration {
 
 func getClient() *TestClient {
 	return &TestClient{
-		Data: prefixfile.VRPList{
+		Data: prefixfile.RPKIList{
 			Metadata: prefixfile.MetaData{},
-			Data:     make([]prefixfile.VRPJson, 0),
+			ROA:      make([]prefixfile.VRPJson, 0),
 		},
 		InitSerial: InitSerial,
 		Serial:     Serial,

--- a/lib/server.go
+++ b/lib/server.go
@@ -354,7 +354,7 @@ func (s *Server) SetSerial(serial uint32) {
 	s.setSerial(serial)
 }
 
-func (s *Server) CountVRPs() int {
+func (s *Server) CountSDs() int {
 	s.sdlock.RLock()
 	defer s.sdlock.RUnlock()
 

--- a/lib/server.go
+++ b/lib/server.go
@@ -145,7 +145,6 @@ type Server struct {
 	sdCurrent       []SendableData
 	sdCurrentSerial uint32
 	keepDiff        int
-	manualserial    bool
 
 	pduRefreshInterval uint32
 	pduRetryInterval   uint32
@@ -285,10 +284,6 @@ func ApplyDiff(diff, prevSDs []SendableData) []SendableData {
 	return newSDs
 }
 
-func (s *Server) SetManualSerial(v bool) {
-	s.manualserial = v
-}
-
 func (s *Server) GetSessionId() uint16 {
 	return s.sessId
 }
@@ -340,7 +335,7 @@ func (s *Server) GenerateSerial() uint32 {
 
 func (s *Server) generateSerial() uint32 {
 	newserial := s.sdCurrentSerial
-	if !s.manualserial && len(s.sdListSerial) > 0 {
+	if len(s.sdListSerial) > 0 {
 		newserial = s.sdListSerial[len(s.sdListSerial)-1] + 1
 	}
 	return newserial

--- a/prefixfile/prefixfile.go
+++ b/prefixfile/prefixfile.go
@@ -8,35 +8,27 @@ import (
 	"time"
 )
 
+type RPKIList struct {
+	Metadata   MetaData                    `json:"metadata,omitempty"`
+	ROA        []VRPJson                   `json:"roas"` // for historical reasons this is called 'roas', but should've been called vrps
+	BgpSecKeys []BgpSecKeyJson             `json:"bgpsec_keys,omitempty"`
+	ASPA       []VAPJson                   `json:"aspas,omitempty"`
+}
+
+type MetaData struct {
+	Counts        int    `json:"vrps"`
+	CountASPAs    int    `json:"aspas"`
+	CountBgpSecKeys int  `json:"bgpsec_pubkeys"`
+	Buildtime     string `json:"buildtime,omitempty"`
+	GeneratedUnix *int64 `json:"generated,omitempty"`
+}
+
 type VRPJson struct {
 	Prefix  string      `json:"prefix"`
 	Length  uint8       `json:"maxLength"`
 	ASN     interface{} `json:"asn"`
 	TA      string      `json:"ta,omitempty"`
 	Expires *int64      `json:"expires,omitempty"`
-}
-
-type MetaData struct {
-	Counts        int    `json:"vrps"`
-	CountASPAs    int    `json:"aspas"`
-	CountBgpSecKeys int  `json:"aspas"`
-	Buildtime     string `json:"buildtime,omitempty"`
-	GeneratedUnix *int64 `json:"generated,omitempty"`
-}
-
-func (md MetaData) GetBuildTime() time.Time {
-	bt, err := time.Parse(time.RFC3339, md.Buildtime)
-	if err != nil {
-		return time.Time{}
-	}
-	return bt
-}
-
-type VRPList struct {
-	Metadata   MetaData                    `json:"metadata,omitempty"`
-	Data       []VRPJson                   `json:"roas"` // for historical reasons this is called 'roas', but should've been called vrps
-	BgpSecKeys []BgpSecKeyJson             `json:"bgpsec_keys,omitempty"`
-	ASPA       []ASPAJson                  `json:"aspas,omitempty"`
 }
 
 type BgpSecKeyJson struct {
@@ -52,11 +44,18 @@ type BgpSecKeyJson struct {
 	Ski string `json:"ski"`
 }
 
-// ASPA
-type ASPAJson struct {
+type VAPJson struct {
 	CustomerAsid uint32   `json:"customer_asid"`
 	Expires      *int64   `json:"expires,omitempty"`
 	Providers    []uint32 `json:"providers"`
+}
+
+func (md MetaData) GetBuildTime() time.Time {
+	bt, err := time.Parse(time.RFC3339, md.Buildtime)
+	if err != nil {
+		return time.Time{}
+	}
+	return bt
 }
 
 func (vrp *VRPJson) GetASN2() (uint32, error) {

--- a/prefixfile/slurm.go
+++ b/prefixfile/slurm.go
@@ -215,9 +215,9 @@ func (s *SlurmValidationOutputFilters) FilterOnBRKs(brks []BgpSecKeyJson) (added
 	return added, removed
 }
 
-func (s *SlurmValidationOutputFilters) FilterOnVAPs(vaps []ASPAJson, ipv6 bool) (added, removed []ASPAJson) {
-	added = make([]ASPAJson, 0)
-	removed = make([]ASPAJson, 0)
+func (s *SlurmValidationOutputFilters) FilterOnVAPs(vaps []VAPJson, ipv6 bool) (added, removed []VAPJson) {
+	added = make([]VAPJson, 0)
+	removed = make([]VAPJson, 0)
 	if s.AspaFilters == nil || len(s.AspaFilters) == 0 {
 		return vaps, removed
 	}
@@ -267,14 +267,14 @@ func (s *SlurmLocallyAddedAssertions) AssertVRPs() []VRPJson {
 	return vrps
 }
 
-func (s *SlurmLocallyAddedAssertions) AssertVAPs() []ASPAJson {
-	vaps := make([]ASPAJson, 0)
+func (s *SlurmLocallyAddedAssertions) AssertVAPs() []VAPJson {
+	vaps := make([]VAPJson, 0)
 
 	if s.AspaAssertions == nil || len(s.AspaAssertions) == 0 {
 		return vaps
 	}
 	for _, assertion := range s.AspaAssertions {
-		vap := ASPAJson{
+		vap := VAPJson{
 			CustomerAsid: assertion.CustomerASNid,
 			Providers:    assertion.ProviderSet,
 		}
@@ -301,15 +301,15 @@ func (s *SlurmLocallyAddedAssertions) AssertBRKs() []BgpSecKeyJson {
 	return brks
 }
 
-func (s *SlurmConfig) GetAssertions() (vrps []VRPJson, vaps []ASPAJson, BRKs []BgpSecKeyJson) {
+func (s *SlurmConfig) GetAssertions() (vrps []VRPJson, vaps []VAPJson, BRKs []BgpSecKeyJson) {
 	vrps = s.LocallyAddedAssertions.AssertVRPs()
 	vaps = s.LocallyAddedAssertions.AssertVAPs()
 	BRKs = s.LocallyAddedAssertions.AssertBRKs()
 	return
 }
 
-func (s *SlurmConfig) FilterAssert(vrps []VRPJson, vaps []ASPAJson, BRKs []BgpSecKeyJson, log Logger) (
-	ovrps []VRPJson, ovaps []ASPAJson, oBRKs []BgpSecKeyJson) {
+func (s *SlurmConfig) FilterAssert(vrps []VRPJson, vaps []VAPJson, BRKs []BgpSecKeyJson, log Logger) (
+	ovrps []VRPJson, ovaps []VAPJson, oBRKs []BgpSecKeyJson) {
 	//
 	filteredVRPs, removedVRPs := s.ValidationOutputFilters.FilterOnVRPs(vrps)
 	filteredVAPs, removedVAPs := s.ValidationOutputFilters.FilterOnVAPs(vaps, false)

--- a/prefixfile/slurm_test.go
+++ b/prefixfile/slurm_test.go
@@ -189,7 +189,7 @@ func TestFilterOnBSKs(t *testing.T) {
 	assert.Equal(t, uint32(65005), removed[2].Asn)
 }
 func TestFilterOnVAPs(t *testing.T) {
-	vrps := []ASPAJson{
+	vrps := []VAPJson{
 		{
 			CustomerAsid: 65001,
 			Providers:    []uint32{65002, 65003},
@@ -242,7 +242,7 @@ func TestSlurmEndToEnd(t *testing.T) {
 	}
 
 	finalVRP, finalASPA, finalBgpsec :=
-		config.FilterAssert(vrplist.Data, vrplist.ASPA, vrplist.BgpSecKeys, nil)
+		config.FilterAssert(vrplist.ROA, vrplist.ASPA, vrplist.BgpSecKeys, nil)
 
 	foundAssertVRP := false
 	for _, vrps := range finalVRP {
@@ -285,11 +285,11 @@ func TestSlurmEndToEnd(t *testing.T) {
 	}
 }
 
-func decodeJSON(data []byte) (*VRPList, error) {
+func decodeJSON(data []byte) (*RPKIList, error) {
 	buf := bytes.NewBuffer(data)
 	dec := json.NewDecoder(buf)
 
-	var vrplistjson VRPList
+	var vrplistjson RPKIList
 	err := dec.Decode(&vrplistjson)
 	return &vrplistjson, err
 }


### PR DESCRIPTION
Cleanup some code that is just confusing because the variables and functions are inappropriately named.
While I can handle ROA vs VRP and ASPA vs VAP, it breaks my mind when VRP refers to all objects in the cache.

Mainly use RPKI for the top level structure that includes VRP, VAP and BgpsecKeys.
Use VAP instead of aspa (at least in those places where VRP is used instead of ROA).
Use items for SendableData objects since those can be VRP, VAP or BgpsecKeys.
Kill a unused function and variable in the server code.
