### PR TITLE
Adjust handling of version-session_id-serial touple

### DIFF
--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -477,7 +477,6 @@ func (s *state) applyUpdateFromNewState(vrps []rtr.VRP, brks []rtr.BgpsecKey, va
 		BgpSecKeys: brksjson,
 		ASPA:       aspajson,
 	}
-
 	s.lockJson.Unlock()
 
 	if s.metricsEvent != nil {

--- a/lib/server.go
+++ b/lib/server.go
@@ -6,20 +6,17 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"net"
 	"net/netip"
 	"sync"
-	"time"
 
 	"golang.org/x/crypto/ssh"
 )
 
 func GenerateSessionId() uint16 {
-	var sessid uint16
-	r := rand.New(rand.NewSource(time.Now().UTC().Unix()))
-	sessid = uint16(r.Uint32())
-	return sessid
+	return uint16(rand.Intn(math.MaxUint16 + 1))
 }
 
 type RTRServerEventHandler interface {


### PR DESCRIPTION
RFC 8210 has this in Section 5.1

```
Note that sessions are specific to a particular protocol version.
That is, if a cache server supports multiple versions of this protocol,
happens to use the same Session ID value for multiple protocol
versions, and further happens to use the same Serial Number
values for two or more sessions using the same Session ID but
different Protocol Version values, the Serial Numbers are not
commensurate. The full test for whether Serial Numbers are
commensurate requires comparing Protocol Version, Session ID,
and Serial Number. To reduce the risk of confusion, cache servers
SHOULD NOT use the same Session ID across multiple protocol
versions, but even if they do, routers MUST treat sessions with
different Protocol Version fields as separate sessions even if they
do happen to have the same Session ID.
```

This changes the code to create session ids and spacing them 100 apart from each other.
With this the `Serial Query` will fail for a system that does a session down/upgrade.