### PR TITLE
Add switch to disable TCP_NODELAY

### DIFF
--- a/lib/server.go
+++ b/lib/server.go
@@ -536,8 +536,16 @@ func (s *Server) Start(bind string) error {
 
 var DisableBGPSec = flag.Bool("disable.bgpsec", false, "Disable sending out BGPSEC Router Keys")
 var DisableASPA = flag.Bool("disable.aspa", false, "Disable sending out ASPA objects")
+var EnableNODELAY = flag.Bool("enable.nodelay", false, "Force enable TCP NODELAY (Likely increases CPU)")
 
 func (s *Server) acceptClientTCP(tcpconn net.Conn) error {
+	if !*EnableNODELAY {
+		tc, ok := tcpconn.(*net.TCPConn)
+		if ok {
+			tc.SetNoDelay(false)
+		}
+	}
+
 	client := ClientFromConn(tcpconn, s, s)
 	client.log = s.log
 	if s.enforceVersion {


### PR DESCRIPTION
This in an attempt quell CPU usage, since PCCW is having issues when their {N} number of routers all start RTR sessions at the same time.

A `perf` of the system suggests all of the CPU is going to sending TCP traffic, and since golang enables NO_DELAY (infamously?) by default, this is a good smoking gun, since this would imply that stayrtr is sending 1 TCP packet per RTR PDU, something that would indeed cause a lot of CPU usage in aggergate!

This patch was written some time ago, but reports from PCCW states that this does actually help their network a noticeable amount, So I think this is a worthy switch to be introduced 