### PR TITLE
Avoid adding empty deltas to the cache

### DIFF
--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -445,10 +445,13 @@ func (s *state) applyUpdateFromNewState(vrps []rtr.VRP, brks []rtr.BgpsecKey, va
 	for _, v := range vaps {
 		SDs = append(SDs, v.Copy())
 	}
-	s.server.AddData(SDs)
+	if (s.server.AddData(SDs) == false) {
+		log.Info("No difference to current cache")
+		return nil
+	}
 
 	serial, _ := s.server.GetCurrentSerial(sessid)
-	log.Infof("Updated added, new serial %v", serial)
+	log.Infof("Update added, new serial %v", serial)
 	if s.sendNotifs {
 		log.Debugf("Sending notifications to clients")
 		s.server.NotifyClientsLatest()

--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -445,7 +445,7 @@ func (s *state) applyUpdateFromNewState(vrps []rtr.VRP, brks []rtr.BgpsecKey, va
 	for _, v := range vaps {
 		SDs = append(SDs, v.Copy())
 	}
-	if (s.server.AddData(SDs) == false) {
+	if !s.server.AddData(SDs) {
 		log.Info("No difference to current cache")
 		return nil
 	}

--- a/lib/server.go
+++ b/lib/server.go
@@ -373,7 +373,7 @@ func (s *Server) AddData(new []SendableData) bool {
 	curDiff := append(added, removed...)
 	s.sdlock.RUnlock()
 
-	if (len(curDiff) == 0) {
+	if len(curDiff) == 0 {
 		return false
 	} else {
 		s.AddSDsDiff(curDiff)

--- a/lib/server.go
+++ b/lib/server.go
@@ -361,7 +361,7 @@ func (s *Server) CountSDs() int {
 	return len(s.sdCurrent)
 }
 
-func (s *Server) AddData(new []SendableData) {
+func (s *Server) AddData(new []SendableData) bool {
 	s.sdlock.RLock()
 
 	added, removed, _ := ComputeDiff(new, s.sdCurrent, false)
@@ -373,7 +373,12 @@ func (s *Server) AddData(new []SendableData) {
 	curDiff := append(added, removed...)
 	s.sdlock.RUnlock()
 
-	s.AddSDsDiff(curDiff)
+	if (len(curDiff) == 0) {
+		return false
+	} else {
+		s.AddSDsDiff(curDiff)
+		return true
+	}
 }
 
 func (s *Server) addSerial(serial uint32) []uint32 {


### PR DESCRIPTION
Return true or false from AddData().
Returns false and aborts the data addition if there is no change in the delta.
Use this to shortcut applyUpdateFromNewState() which prevents sending out notifications for empty deltas.

While detecting no file change for slurm using a hash (#115) prevents this case it still is an extra safety to prevent empty deltas to show up.