### PR TITLE
Use debug level logging for hash change

### DIFF
--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -519,7 +519,7 @@ func (s *state) updateFile(file string) (bool, error) {
 		}
 	}
 
-	log.Infof("new cache file: Updating sha256 hash %x -> %x", s.lasthashCache, hsum)
+	log.Debugf("new cache file: Updating sha256 hash %x -> %x", s.lasthashCache, hsum)
 	s.lasthashCache = hsum
 
 	rpkilistjson, err := decodeJSON(data)
@@ -553,7 +553,7 @@ func (s *state) updateSlurm(file string) (bool, error) {
 			return false, IdenticalFile{File: file}
 		}
 	}
-	log.Infof("new slurm file: Updating sha256 hash %x -> %x", s.lasthashCache, hsum)
+	log.Debugf("new slurm file: Updating sha256 hash %x -> %x", s.lasthashCache, hsum)
 	s.lasthashSlurm = hsum
 
 	buf := bytes.NewBuffer(data)


### PR DESCRIPTION
@cjeker: I thought I had pushed this. I did see "ah I force pushed a commit, that is the logging change", but that was not this change.