### PR TITLE
Increase maximum PDU length that is decoded

### DIFF
--- a/lib/structs.go
+++ b/lib/structs.go
@@ -19,7 +19,8 @@ type Logger interface {
 }
 
 const (
-	messageMaxSize = 2048
+	// arbitrary threshold. First power of two over 4*|asns in DFZ|
+	messageMaxSize = 1048576
 
 	PROTOCOL_VERSION_0 = 0
 	PROTOCOL_VERSION_1 = 1

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -19,8 +19,16 @@ type Logger interface {
 }
 
 const (
-	// arbitrary threshold. First power of two over 4*|asns in DFZ|
-	messageMaxSize = 1048576
+	// We use the size of the largest sensible PDU.
+	//
+	// We ignore the theoretically unbounded length of SKIs for router keys.
+	// RPs should validate that this has the correct length.
+	//
+	// maximum size of ASPA PDU payload:
+	// * 2^16 providers * 32bit = 262144 bytes
+	// * length is inclusive of header: 8 bytes
+	// * flags/afi flags/provider as/customer AS: 16 bytes
+	messageMaxSize = 262168
 
 	PROTOCOL_VERSION_0 = 0
 	PROTOCOL_VERSION_1 = 1


### PR DESCRIPTION
Limit the maximum PDU length that is decoded to a size that is both safe for the software as well as unrealistic in the DFZ. This path is only hit when using rtrdump, rtrmon, or when using starter as a library.

It is very feasible to create a ASPA PDU > 2k.

@cjeker this is more relevant in real BGP speakers.