### PR TITLE
Switch to RTR version 0 - RFC 6810; the ASPA work still is in flux hindering users

### DIFF
--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -53,7 +53,7 @@ var (
 
 	ExportPath = flag.String("export.path", "/rpki.json", "Export path")
 
-	RTRVersion = flag.Int("protocol", 0, "RTR protocol version. Default is version 0 (RFC 6810)")
+	RTRVersion = flag.Int("protocol", 1, "RTR protocol version. Default is version 0 (RFC 6810)")
 	RefreshRTR = flag.Int("rtr.refresh", 3600, "Refresh interval")
 	RetryRTR   = flag.Int("rtr.retry", 600, "Retry interval")
 	ExpireRTR  = flag.Int("rtr.expire", 7200, "Expire interval")

--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -53,7 +53,7 @@ var (
 
 	ExportPath = flag.String("export.path", "/rpki.json", "Export path")
 
-	RTRVersion = flag.Int("protocol", 1, "RTR protocol version. Default is version 0 (RFC 6810)")
+	RTRVersion = flag.Int("protocol", 1, "RTR protocol version. Default is version 1 (RFC 8210)")
 	RefreshRTR = flag.Int("rtr.refresh", 3600, "Refresh interval")
 	RetryRTR   = flag.Int("rtr.retry", 600, "Retry interval")
 	ExpireRTR  = flag.Int("rtr.expire", 7200, "Expire interval")

--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -53,7 +53,7 @@ var (
 
 	ExportPath = flag.String("export.path", "/rpki.json", "Export path")
 
-	RTRVersion = flag.Int("protocol", 2, "RTR protocol version. Version 2 is draft-ietf-sidrops-8210bis-10")
+	RTRVersion = flag.Int("protocol", 0, "RTR protocol version. Default is version 0 (RFC 6810)")
 	RefreshRTR = flag.Int("rtr.refresh", 3600, "Refresh interval")
 	RetryRTR   = flag.Int("rtr.retry", 600, "Retry interval")
 	ExpireRTR  = flag.Int("rtr.expire", 7200, "Expire interval")


### PR DESCRIPTION
Switch to RTR version 0 by default (RFC 6810); the ASPA work still is in flux hindering users.

We can revisit this choice in a few months