### PR TITLE
Manually set the version into the apps

### DIFF
--- a/cmd/rtrdump/rtrdump.go
+++ b/cmd/rtrdump/rtrdump.go
@@ -27,9 +27,7 @@ const (
 )
 
 var (
-	version    = ""
-	buildinfos = ""
-	AppVersion = "RTRdump " + version + " " + buildinfos
+	AppVersion = "RTRdump " + rtr.APP_VERSION
 
 	Connect = flag.String("connect", "127.0.0.1:8282", "Connection address")
 	OutFile = flag.String("file", "output.json", "Output file")

--- a/cmd/rtrmon/rtrmon.go
+++ b/cmd/rtrmon/rtrmon.go
@@ -42,9 +42,7 @@ const (
 type thresholds []int64
 
 var (
-	version    = ""
-	buildinfos = ""
-	AppVersion = "RTRmon " + version + " " + buildinfos
+	AppVersion = "RTRmon " + rtr.APP_VERSION
 	//go:embed index.html.tmpl
 	IndexTemplate string
 

--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -44,9 +44,7 @@ const (
 )
 
 var (
-	version    = ""
-	buildinfos = ""
-	AppVersion = "StayRTR " + version + " " + buildinfos
+	AppVersion = "StayRTR " + rtr.APP_VERSION
 
 	MetricsAddr = flag.String("metrics.addr", ":9847", "Metrics address")
 	MetricsPath = flag.String("metrics.path", "/metrics", "Metrics path")

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -19,6 +19,8 @@ type Logger interface {
 }
 
 const (
+	APP_VERSION = "0.6.0"
+
 	// We use the size of the largest sensible PDU.
 	//
 	// We ignore the theoretically unbounded length of SKIs for router keys.


### PR DESCRIPTION
It appears that Go's method of feeding in the actual version highly depends on whether you build via make or via some other pipeline.

Hardcoding the application's version number in 1 place seems a reasonable approach