### PR TITLE
ARM64 builds and workflow updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Set latest stable go version
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: 'stable'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
         go-version: 'stable'
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: '0'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,13 +24,13 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         queries: +security-and-quality
         languages: go
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Get short SHA from commit hash
         id: tagcalc
-        run: echo "::set-output name=tagname::$(git describe --tags --abbrev=0 HEAD)"
+        run: echo "tagname=$(git describe --tags --abbrev=0 HEAD)" >> $GITHUB_OUTPUT
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get short SHA from commit hash
         id: tagcalc

--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -18,7 +18,7 @@ jobs:
         run: echo "::set-output name=tagname::$(git describe --tags --abbrev=0 HEAD)"
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Get short SHA from commit hash
         id: shacalc
-        run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+        run: echo "sha8=${GITHUB_SHA:0:8}" >> $GITHUB_OUTPUT
 
       - name: Check Out Repo
         uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
         run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
       - name: Check Out Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -52,7 +52,7 @@ jobs:
         GOARCH=arm64 make package-deb-stayrtr package-rpm-stayrtr
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist/*

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,23 +28,28 @@ jobs:
     - name: Build
       run: |
         GOOS=linux make build-stayrtr
+        GOOS=linux GOARCH=arm64 make build-stayrtr
         GOOS=darwin make build-stayrtr
         GOOS=windows EXTENSION=.exe make build-stayrtr
         GOOS=linux make build-rtrdump
+        GOOS=linux GOARCH=arm64 make build-rtrdump
         GOOS=darwin make build-rtrdump
         GOOS=windows EXTENSION=.exe make build-rtrdump
         GOOS=linux make build-rtrmon
+        GOOS=linux GOARCH=arm64 make build-rtrmon
         GOOS=darwin make build-rtrmon
         GOOS=windows EXTENSION=.exe make build-rtrmon
-    
+
     - name: Install fpm
       run: |
         sudo apt-get update
         sudo apt-get install -y rpm ruby ruby-dev
         sudo gem install fpm
-          
+
     - name: Package
-      run: make package-deb-stayrtr package-rpm-stayrtr
+      run: |
+        make package-deb-stayrtr package-rpm-stayrtr
+        GOARCH=arm64 make package-deb-stayrtr package-rpm-stayrtr
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: '0'
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 EXTENSION ?= 
 DIST_DIR ?= dist/
 GOOS ?= linux
-ARCH ?= $(shell uname -m)
+GOARCH ?= x86_64
+ARCH ?= $(GOARCH)
 BUILDINFOSDET ?= 
 
 DOCKER_REPO   := rpki/
 STAYRTR_NAME    := stayrtr
 STAYRTR_VERSION := $(shell git describe --tags $(git rev-list --tags --max-count=1))
 VERSION_PKG   := $(shell echo $(STAYRTR_VERSION) | sed 's/^v//g')
-ARCH          := x86_64
 LICENSE       := BSD-3
 URL           := https://github.com/bgp/stayrtr
 DESCRIPTION   := StayRTR: a RPKI-to-Router server


### PR DESCRIPTION
In the Makefile `ARCH` was hardcoded to `x86_64`. This PR makes everything dependent on GOARCH variable, additionally doing the arm64 build in the GitHub workflow.

There are also various workflow updates due to deprecation of old Node.js versions, old CodeQL actions and `::set-output` syntax. There might be more places that need to be updated.