### PR TITLE
Automatically attach artifacts to version release (+ fixes)

### DIFF
--- a/.github/workflows/go-tag.yml
+++ b/.github/workflows/go-tag.yml
@@ -1,0 +1,26 @@
+name: Tagged Go build
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  go:
+    name: Go
+    uses: ./.github/workflows/go.yml
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [go]
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
         fetch-depth: '0'
 
     - name: Set up go version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  # This workflow is re-used in go-tag.yml
   workflow_call:
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ package-rpm-stayrtr: prepare
 	--url "$(URL)" \
 	--architecture $(ARCH) \
 	--license "$(LICENSE) "\
-	--package $(DIST_DIR) \
 	$(OUTPUT_STAYRTR)=/usr/bin/stayrtr \
 	package/.keep=/usr/share/stayrtr/.keep \
 	package/stayrtr.service=/lib/systemd/system/stayrtr.service \


### PR DESCRIPTION
There are three packaging/workflow related changes in this PR:

1. It seems that `fpm` not saving the artifact in the `dist/` directory is not the only problem. Actually the resulting RPMs contain the whole `dist` directory with all the binary artifacts for all the architectures! First commit removes the `--package $(DIST_DIR)` option from `fpm` invocation when generating the RPM, fixing the issue.
2. Second commit is just an upgrade of GitHub action to the latest version.
3. Third one will automatically create a GitHub release with the artifacts whenever a version tag is added to the repository. This way I can always download the latest package from GitHub and don't have to generate it on my own. Note that the latest release is missing the binaries.