### PR TITLE
rtrdump: add sessionid and serial to json output

### DIFF
--- a/cmd/rtrdump/rtrdump.go
+++ b/cmd/rtrdump/rtrdump.go
@@ -113,6 +113,8 @@ func (c *Client) HandlePDU(cs *rtr.ClientSession, pdu rtr.PDU) {
 			log.Debugf("Received: %v", pdu)
 		}
 	case *rtr.PDUEndOfData:
+		c.Data.Metadata.SessionID = int(pdu.SessionId)
+		c.Data.Metadata.Serial = int(pdu.SerialNumber)
 		cs.Disconnect()
 		log.Debugf("Received: %v", pdu)
 	case *rtr.PDUCacheResponse:

--- a/prefixfile/prefixfile.go
+++ b/prefixfile/prefixfile.go
@@ -19,6 +19,8 @@ type MetaData struct {
 	CountBgpSecKeys int  `json:"bgpsec_pubkeys"`
 	Buildtime     string `json:"buildtime,omitempty"`
 	GeneratedUnix *int64 `json:"generated,omitempty"`
+	SessionID        int `json:"sessionid,omitempty"`
+	Serial           int `json:"serial"`
 }
 
 type VRPJson struct {


### PR DESCRIPTION
To diagnose RTR issues its very useful to have access to sessionid and serial fields.

Discussed in #102