### PR TITLE
Add stayrtr info (hostname and version) in metrics output

### DIFF
--- a/cmd/stayrtr/stayrtr.go
+++ b/cmd/stayrtr/stayrtr.go
@@ -96,6 +96,17 @@ var (
 	LogVerbose = flag.Bool("log.verbose", true, "Additional debug logs (disable with -log.verbose=false)")
 	Version    = flag.Bool("version", false, "Print version")
 
+	Info = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "rtr_info",
+			Help: "stayrtr info.",
+			ConstLabels: prometheus.Labels{
+				"nodename":	os.Hostname(),
+				"version":	AppVersion,
+			},
+		},
+		func() float64 { return 1 },
+	)
 	NumberOfVRPs = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "rpki_vrps",
@@ -159,6 +170,7 @@ var (
 )
 
 func initMetrics() {
+	prometheus.MustRegister(Info)
 	prometheus.MustRegister(NumberOfObjects)
 	prometheus.MustRegister(NumberOfVRPs)
 	prometheus.MustRegister(LastChange)


### PR DESCRIPTION
Untested.

This diff should add the hostname and version in the metrics output.

Expected result:
```
# HELP rtr_info stayrtr info.
# TYPE rtr_info gauge
rtr_info{nodename="<hostname>",version="StayRTR 0.6.1"} 1
```

This would be similar to what bgplgd and rpki-client metrics offer:
```
# HELP bgpd bgpd information
# TYPE bgpd info
bgpd_info{nodename="<hostname>",domainname="<domainname>",release="8.6"} 1
```
or
```
# HELP rpki_client rpki-client information
# TYPE rpki_client gauge
rpki_client_info{nodename="<hostname>",domainname="<domainname>",release="9.3"} 1
```