### PR TITLE
Minor typo fix in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ $ openssl req -new -x509 -key private.pem -out server.pem
 Then, you have to run
 
 ```bash
-$ ./stayrtr -ssh.bind :8282 -tls.key private.pem -tls.cert server.pem
+$ ./stayrtr -tls.bind :8282 -tls.key private.pem -tls.cert server.pem
 ```
 
 ### With SSH


### PR DESCRIPTION
Hello,

I was reading the README and spotted a typo, so I fixed it. I assumed that the keyword is tls based on https://github.com/bgp/stayrtr/blob/master/lib/server.go#L615 but I may be wrong as I’m not a programmer.