### PR TITLE
Add govulncheck to ci/cd

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,12 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
+    - id: govulncheck
+      uses: golang/govulncheck-action@v1
+      with:
+        go-version-file: 'go.mod'
+        go-package: ./...
+
     - name: Test & Vet
       run: make test vet
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILDINFOSDET ?=
 
 DOCKER_REPO   := rpki/
 STAYRTR_NAME    := stayrtr
-STAYRTR_VERSION := $(shell git describe --tags $(git rev-list --tags --max-count=1))
+STAYRTR_VERSION := $(shell git describe --always --tags $(git rev-list --tags --max-count=1))
 VERSION_PKG   := $(shell echo $(STAYRTR_VERSION) | sed 's/^v//g')
 LICENSE       := BSD-3
 URL           := https://github.com/bgp/stayrtr


### PR DESCRIPTION
Add govulncheck, a conservative static analyzer that checks the reachability of vulnerabilities.

This provides an upper bound on the actual vulnerabilities that are applicable, and is lower-noise than generic checks that check if a vulnerable library is used.

closes #139 