### PR TITLE
feat: add http endpoint to view connected clients

### DIFF
--- a/lib/server.go
+++ b/lib/server.go
@@ -3,11 +3,13 @@ package rtrlib
 import (
 	"bytes"
 	"crypto/tls"
+        "encoding/json"
 	"fmt"
 	"io"
 	"math"
 	"math/rand"
 	"net"
+        "net/http"
 	"net/netip"
 	"sync"
 
@@ -417,6 +419,15 @@ func (s *Server) SetMaxConnections(maxconn int) {
 
 func (s *Server) GetMaxConnections() int {
 	return s.maxconn
+}
+
+func (s *Server) GetClientRemoteAddrs(w http.ResponseWriter, r *http.Request) {
+	clients := s.GetClientList()
+	out := make([]string, len(clients))
+	for i, c := range clients {
+		out[i] = c.GetRemoteAddress().String()
+	}
+	json.NewEncoder(w).Encode(out)
 }
 
 func (s *Server) ClientConnected(c *Client) {


### PR DESCRIPTION
This change adds an http server endpoint to dump currently connected clients. While one can potentially scrape this from logs I have a use case that would be better served if this were exposed in a structured output format.

While we are at it this change move to a dedicated ServeMux and away from the default mux. Recent changes to go [changed the way the default servemux works](https://github.com/golang/go/issues/69044) making it very challenging to (for example) enable and use things like `pprof` which I had to do while debugging #90 