### PR TITLE
Update required go version in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Special thanks for support to the Route Server Support Foundation [RSSF](https:/
 
 ## To start developing
 
-You need a working [Go environment](https://golang.org/doc/install) (1.17 or newer).
+You need a working [Go environment](https://golang.org/doc/install) (1.23 or newer).
 This project also uses [Go Modules](https://github.com/golang/go/wiki/Modules).
 
 ```bash


### PR DESCRIPTION
`toolchain` requires 1.21 at least, go.mod itself specifies 1.23