### PR TITLE
Fix version error report race: write directly before disconnect

### DIFF
--- a/lib/server.go
+++ b/lib/server.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/netip"
 	"sync"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/sync/errgroup"
@@ -734,7 +735,18 @@ func (c *Client) checkVersion(newversion uint8) error {
 		if c.log != nil {
 			c.log.Debugf("%v: has bad version (received: v%v, current: v%v) error", c.String(), newversion, c.version)
 		}
+		// Send the Error Report through the normal channel, then give
+		// sendLoop time to flush it before we disconnect. The error
+		// report must use the server's highest supported version so the
+		// client knows what to downgrade to (RFC 8210 §7).
+		if !c.versionset {
+			c.SetVersion(PROTOCOL_VERSION_1)
+		}
 		c.SendWrongVersionError()
+		// Brief yield to let sendLoop drain the error report. Not
+		// guaranteed, but materially reduces the race window vs the
+		// previous immediate-disconnect path.
+		time.Sleep(50 * time.Millisecond)
 		c.Disconnect()
 		return fmt.Errorf("%v: has bad version (received: v%v, current: v%v)", c.String(), newversion, c.version)
 	}
@@ -805,7 +817,11 @@ func (c *Client) readLoop(ctx context.Context) error {
 					if c.log != nil {
 						c.log.Debugf("Bad version error")
 					}
+					// c.version already holds the server's enforced version
+					// (set at connection accept time), so SendWrongVersionError
+					// stamps the correct version for the client to downgrade to.
 					c.SendWrongVersionError()
+					time.Sleep(50 * time.Millisecond)
 					c.Disconnect()
 					return fmt.Errorf("%s: bad version error", c.String())
 				}


### PR DESCRIPTION
When a client connects with an unsupported protocol version (e.g., RTR v2 to a v1 server), SendWrongVersionError() puts the Error Report PDU on the async transmits channel, then Disconnect() immediately cancels the context. The sendLoop selects on both transmits and ctx.Done() — if the cancellation fires first, the error report never reaches the wire.

This causes RTR v2 clients to never receive the Error Report with code 4 (Unsupported Protocol Version) per RFC 8210 section 10. Without it, clients cannot learn they should downgrade and instead retry with v2 indefinitely.

## Fix

**Error Report version byte:** The Error Report now carries PROTOCOL_VERSION_1 (the server's highest supported version) instead of echoing back the client's unsupported version. Per RFC 8210 section 7, the client uses this version field to know what to retry with.

**Delivery before disconnect:** Uses the existing SendWrongVersionError() async channel (preserving write serialization for both TCP and SSH transports) with a brief sleep before Disconnect() to give sendLoop time to flush. The direct c.wr.Write() approach was unsafe for SSH transports (c.wr can be ssh.Channel, which does not document concurrent write safety) and raced with sendLoop.

The sleep is pragmatic — a cleaner approach would be a synchronous flush on the transmits channel. Happy to iterate.

## Affected code paths

- checkVersion() — first PDU from client has unsupported version
- enforceVersion block in readLoop() — subsequent PDU has wrong version

## Testing

- All existing tests pass: go build ./..., go test ./..., go vet ./...
- No existing tests cover the version rejection path — new tests for on-wire Error Report version and code would strengthen this but are not included in this patch

## Context

Discovered via interop testing with a Rust RTR client (rustbgpd). Client-side workaround: https://github.com/lance0/rustbgpd/commit/c1d0296

Fixes #165